### PR TITLE
Bring back accessory category

### DIFF
--- a/draft-detecting-unwanted-location-trackers.md
+++ b/draft-detecting-unwanted-location-trackers.md
@@ -584,7 +584,7 @@ If none of the accessory categories provided in {{table-accessory-category-value
 | Transportation device      | 165         |
 | Sports equipment           | 166         |
 | Personal item              | 167         |
-| Reserved for future use    | 2-127, 167+ |
+| Reserved for future use    | 2-127, 168+ |
 {: #table-accessory-category-values title="Accessory Category Values"}
 
 # Firmware Updates


### PR DESCRIPTION
 The accessory category provides robustness for UT alerts as it can provide more detail about what type of item the location tracking is associated with. This is useful when a network connection is not available to retrieve the additional Product Data details.