### PR TITLE
Change 'Finder' -> 'Location-Tracker'

### DIFF
--- a/draft-detecting-unwanted-location-trackers.md
+++ b/draft-detecting-unwanted-location-trackers.md
@@ -554,8 +554,8 @@ Accessory manufacturer’s MUST pick an accessory category value that closest re
 If none of the accessory categories provided in {{table-accessory-category-values}} match the physical product, Other MUST be chosen.
 
 | Accessory Category Name    | Value       |
-|:---------------------------|:-----------:
-| Finder                     | 1           |
+|:---------------------------|:------------:
+| Location-Tracker           | 1           |
 | Other                      | 128         |
 | Luggage                    | 129         |
 | Backpack                   | 130         |


### PR DESCRIPTION
'Finder' terminology used in the accessory category table is confusing, update this to be more clear.