### PR TITLE
Fixed 3 spelling errors

### DIFF
--- a/draft-detecting-unwanted-location-trackers.md
+++ b/draft-detecting-unwanted-location-trackers.md
@@ -562,7 +562,7 @@ The accessory manufacturer SHALL provide both a text description of how to enabl
 ### Identifier retrieval from a server {#identifier-from-server}
 For security reasons, the identifier payload returned from an accessory in the paired state SHALL be encrypted.
 
-### Idenitifer over NFC {#identifier-over-nfc}
+### Identifier over NFC {#identifier-over-nfc}
 For those accessories that support identifier retrieval over NFC, an associated accessory SHALL advertise the encrypted serial number encoded as a hex string. This string SHALL be an argument passed to the URL defined in the [Product data registry](product-data-registry) which SHALL decrypt the identifier payload and return the identifier of the accessory in a form that can be rendered in the platform's HTML view.
 
 The encrypted identifier when in associated state SHALL be an argument passed to this URL and it is REQUIRED that any metadata passed be non-identifiable.


### PR DESCRIPTION
Ran Mac's spellcheck and found these (3 of which need to be fixed):

bledvina@MBP-M2-3 draft-detecting-unwanted-location-trackers % spellcheck draft-detecting-unwanted-location-trackers.md docname
submissiontype
github
bdetwiler@apple.com
Siddika
siddikap@google.com
DownloadDoc.ashx
bcp14-tagged
Get_Network_ID_Reponse
Implemention
implemention
table-non-owner-control-pt-opcodes
table-non-owner-control-pt-opcodes
table-sn-payload-over-bt
accessory-finding-hw
accessory-finding-hw
identifier-over-nfc
identifier-retrieval-over-bluetooth-le
Identifer
identifier-over-nfc
unassociates
unlinkable
unlinkable